### PR TITLE
Connector test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Property `ignoreExceptionOnFailure` was added in `SeniorXHTTPRouteBuilder` builder and `AuthenticationAPI` constructor.
+- Property `throwExceptionOnFailure` was added in `SeniorXHTTPRouteBuilder` builder and `AuthenticationAPI` constructor. Default value: `true`.
+  *  By default, Camel throws `HttpOperationFailedException` for failed response codes. If set to `false`, allows you to get any response from the remote server.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [1.2.0] - 2022-05-13
+
+### Added
+
 - Property `throwExceptionOnFailure` was added in `SeniorXHTTPRouteBuilder` builder and `AuthenticationAPI` constructor. Default value: `true`.
   *  By default, Camel throws `HttpOperationFailedException` for failed response codes. If set to `false`, allows you to get any response from the remote server.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Property `ignoreExceptionOnFailure` was added in `SeniorXHTTPRouteBuilder` builder and `AuthenticationAPI` constructor.
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Fixed
-
-### Removed
+- Attribute `path` in `PrimitiveType` set to public.
 
 ## [1.1.0] - 2022-04-04
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.com.senior</groupId>
 	<artifactId>seniorx-http-camel-api</artifactId>
-	<version>1.2.0-alpha-1</version>
+	<version>1.2.0-alpha-2</version>
 	<packaging>jar</packaging>
 
 	<name>Senior X HTTP Camel API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.com.senior</groupId>
 	<artifactId>seniorx-http-camel-api</artifactId>
-	<version>1.1.0</version>
+	<version>1.2.0-alpha-0</version>
 	<packaging>jar</packaging>
 
 	<name>Senior X HTTP Camel API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.com.senior</groupId>
 	<artifactId>seniorx-http-camel-api</artifactId>
-	<version>1.2.0-alpha-3</version>
+	<version>1.2.0</version>
 	<packaging>jar</packaging>
 
 	<name>Senior X HTTP Camel API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.com.senior</groupId>
 	<artifactId>seniorx-http-camel-api</artifactId>
-	<version>1.2.0-alpha-0</version>
+	<version>1.2.0-alpha-1</version>
 	<packaging>jar</packaging>
 
 	<name>Senior X HTTP Camel API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>br.com.senior</groupId>
 	<artifactId>seniorx-http-camel-api</artifactId>
-	<version>1.2.0-alpha-2</version>
+	<version>1.2.0-alpha-3</version>
 	<packaging>jar</packaging>
 
 	<name>Senior X HTTP Camel API</name>

--- a/src/main/java/br/com/senior/seniorx/http/camel/PrimitiveType.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/PrimitiveType.java
@@ -7,7 +7,7 @@ public enum PrimitiveType {
     SIGNAL("signals"), //
     ENTITY("entities"); //
 
-    final String path;
+    public final String path;
 
     PrimitiveType(String path) {
         this.path = path;

--- a/src/main/java/br/com/senior/seniorx/http/camel/SeniorXHTTPRouteBuilder.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/SeniorXHTTPRouteBuilder.java
@@ -43,7 +43,7 @@ public class SeniorXHTTPRouteBuilder {
     protected String service;
     protected PrimitiveType primitiveType;
     protected String primitive;
-    protected boolean ignoreExceptionOnFailure = false;
+    protected boolean ignoreExceptionOnFailure = true;
 
     public SeniorXHTTPRouteBuilder(RouteBuilder builder) {
         this.builder = builder;
@@ -86,6 +86,11 @@ public class SeniorXHTTPRouteBuilder {
 
     public SeniorXHTTPRouteBuilder primitive(String primitive) {
         this.primitive = primitive;
+        return this;
+    }
+
+    public SeniorXHTTPRouteBuilder ignoreExceptionOnFailure(boolean ignoreExceptionOnFailure) {
+        this.ignoreExceptionOnFailure = ignoreExceptionOnFailure;
         return this;
     }
 

--- a/src/main/java/br/com/senior/seniorx/http/camel/SeniorXHTTPRouteBuilder.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/SeniorXHTTPRouteBuilder.java
@@ -43,6 +43,7 @@ public class SeniorXHTTPRouteBuilder {
     protected String service;
     protected PrimitiveType primitiveType;
     protected String primitive;
+    protected boolean ignoreExceptionOnFailure = false;
 
     public SeniorXHTTPRouteBuilder(RouteBuilder builder) {
         this.builder = builder;
@@ -105,6 +106,10 @@ public class SeniorXHTTPRouteBuilder {
                 + '/' + primitiveType.path //
                 + '/' + primitive //
                 ;
+
+        if (!ignoreExceptionOnFailure) {
+            route += "?throwExceptionOnFailure=false";
+        }
 
         Message message = exchange.getMessage();
         message.setHeader("Content-Type", "application/json");

--- a/src/main/java/br/com/senior/seniorx/http/camel/SeniorXHTTPRouteBuilder.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/SeniorXHTTPRouteBuilder.java
@@ -43,7 +43,7 @@ public class SeniorXHTTPRouteBuilder {
     protected String service;
     protected PrimitiveType primitiveType;
     protected String primitive;
-    protected boolean ignoreExceptionOnFailure = true;
+    protected boolean throwExceptionOnFailure = true;
 
     public SeniorXHTTPRouteBuilder(RouteBuilder builder) {
         this.builder = builder;
@@ -89,8 +89,8 @@ public class SeniorXHTTPRouteBuilder {
         return this;
     }
 
-    public SeniorXHTTPRouteBuilder ignoreExceptionOnFailure(boolean ignoreExceptionOnFailure) {
-        this.ignoreExceptionOnFailure = ignoreExceptionOnFailure;
+    public SeniorXHTTPRouteBuilder throwExceptionOnFailure(boolean throwExceptionOnFailure) {
+        this.throwExceptionOnFailure = throwExceptionOnFailure;
         return this;
     }
 
@@ -112,7 +112,7 @@ public class SeniorXHTTPRouteBuilder {
                 + '/' + primitive //
                 ;
 
-        if (!ignoreExceptionOnFailure) {
+        if (!throwExceptionOnFailure) {
             route += "?throwExceptionOnFailure=false";
         }
 

--- a/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
@@ -63,7 +63,7 @@ public class AuthenticationAPI {
     private final String route = "direct:seniorx-authentication-" + id.toString();
     private final String to = "direct:seniorx-authentication-response-" + id.toString();
 
-    private boolean ignoreExceptionOnFailure = true;
+    private boolean throwExceptionOnFailure = true;
 
     public AuthenticationAPI(RouteBuilder builder) {
         this.builder = builder;
@@ -71,7 +71,7 @@ public class AuthenticationAPI {
 
     public AuthenticationAPI(RouteBuilder builder, boolean ignoreExceptionOnFailure) {
         this.builder = builder;
-        this.ignoreExceptionOnFailure = ignoreExceptionOnFailure;
+        this.throwExceptionOnFailure = ignoreExceptionOnFailure;
     }
 
     public String route() {
@@ -192,7 +192,7 @@ public class AuthenticationAPI {
         .service(AUTHENTICATION) //
         .primitiveType(ACTION) // .
         .primitive("login")
-        .ignoreExceptionOnFailure(ignoreExceptionOnFailure);
+        .throwExceptionOnFailure(throwExceptionOnFailure);
 
         builder //
         .from(DIRECT_LOGIN) //
@@ -216,7 +216,7 @@ public class AuthenticationAPI {
         .primitiveType(ACTION) //
         .primitive("loginWithKey") //
         .anonymous(true)
-        .ignoreExceptionOnFailure(ignoreExceptionOnFailure);
+        .throwExceptionOnFailure(throwExceptionOnFailure);
 
         builder //
         .from(DIRECT_LOGIN_WITH_KEY) //
@@ -239,7 +239,7 @@ public class AuthenticationAPI {
         .service(AUTHENTICATION) //
         .primitiveType(ACTION) // .
         .primitive("refreshToken")
-        .ignoreExceptionOnFailure(ignoreExceptionOnFailure);
+        .throwExceptionOnFailure(throwExceptionOnFailure);
 
         builder //
         .from(DIRECT_REFRESH_TOKEN) //

--- a/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
@@ -63,8 +63,15 @@ public class AuthenticationAPI {
     private final String route = "direct:seniorx-authentication-" + id.toString();
     private final String to = "direct:seniorx-authentication-response-" + id.toString();
 
+    private boolean ignoreExceptionOnFailure = true;
+
     public AuthenticationAPI(RouteBuilder builder) {
         this.builder = builder;
+    }
+
+    public AuthenticationAPI(RouteBuilder builder, boolean ignoreExceptionOnFailure) {
+        this.builder = builder;
+        this.ignoreExceptionOnFailure = ignoreExceptionOnFailure;
     }
 
     public String route() {
@@ -181,7 +188,8 @@ public class AuthenticationAPI {
         .domain(PLATFORM) //
         .service(AUTHENTICATION) //
         .primitiveType(ACTION) // .
-        .primitive("login");
+        .primitive("login")
+        .ignoreExceptionOnFailure(ignoreExceptionOnFailure);
 
         builder //
         .from(DIRECT_LOGIN) //
@@ -204,7 +212,8 @@ public class AuthenticationAPI {
         .service(AUTHENTICATION) //
         .primitiveType(ACTION) //
         .primitive("loginWithKey") //
-        .anonymous(true);
+        .anonymous(true)
+        .ignoreExceptionOnFailure(ignoreExceptionOnFailure);
 
         builder //
         .from(DIRECT_LOGIN_WITH_KEY) //
@@ -226,7 +235,8 @@ public class AuthenticationAPI {
         .domain(PLATFORM) //
         .service(AUTHENTICATION) //
         .primitiveType(ACTION) // .
-        .primitive("refreshToken");
+        .primitive("refreshToken")
+        .ignoreExceptionOnFailure(ignoreExceptionOnFailure);
 
         builder //
         .from(DIRECT_REFRESH_TOKEN) //

--- a/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
@@ -69,9 +69,9 @@ public class AuthenticationAPI {
         this.builder = builder;
     }
 
-    public AuthenticationAPI(RouteBuilder builder, boolean ignoreExceptionOnFailure) {
+    public AuthenticationAPI(RouteBuilder builder, boolean throwExceptionOnFailure) {
         this.builder = builder;
-        this.throwExceptionOnFailure = ignoreExceptionOnFailure;
+        this.throwExceptionOnFailure = throwExceptionOnFailure;
     }
 
     public String route() {

--- a/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
@@ -271,6 +271,7 @@ public class AuthenticationAPI {
         exchange.setProperty(TOKEN_CACHE_KEY, key);
         token = TOKEN_CACHE.get(key);
         if (token != null) {
+            exchange.setProperty(TOKEN, token);
             exchange.getMessage().setBody(token);
         }
     }

--- a/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
+++ b/src/main/java/br/com/senior/seniorx/http/camel/authentication/AuthenticationAPI.java
@@ -150,6 +150,9 @@ public class AuthenticationAPI {
         .unmarshal(LoginOutput.LOGIN_OUTPUT_FORMAT) //
         .process(this::unmarshallToken) //
 
+        .otherwise() // Token not expired, guarantees it has Authorization header
+        .process(AuthenticationAPI::addAuthorization)
+
         .end() // Expired token
         ;
     }


### PR DESCRIPTION
Apache Camel by default throws an exception when receiving an error response. I added a new property in the SeniorXHTTPRouterBuilder that allows to get any response from the remote server. I added it in the AuthenticationAPI constructor as well.

I also set to public the path attribute in PrimitiveType to be easier to compare the values and build the route when creating a dynamic rest application